### PR TITLE
fix: Use more generic Collection as return type to avoid casting

### DIFF
--- a/src/main/java/jdbi_modules/Collector.java
+++ b/src/main/java/jdbi_modules/Collector.java
@@ -44,7 +44,7 @@ public interface Collector<CollectionType extends Collection<Type>, Type> {
      * @param <T>  the type to filter by
      * @return a filtered stream currently stored in the collector
      */
-    default <T extends Type> List<T> get(@NotNull Class<T> type) {
+    default <T extends Type> Collection<T> get(@NotNull Class<T> type) {
         return stream(type).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Right now, I have to cast explicitly which results in an unchecked code warning by the compiler, e.g. in:

```java
moduleMeta.callSubmodule(GenexExercise.class, (Collection) collector.get(GenexExercise.class), moduleMapper);
```