### PR TITLE
fix: Use more permissive routing function to allow certain special chars

### DIFF
--- a/src/main/java/jdbi_modules/base/StructuredSqlGenerator.java
+++ b/src/main/java/jdbi_modules/base/StructuredSqlGenerator.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
  * @since 14.04.2018
  */
 public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<StructuredSql> {
-    Pattern PATTERN = Pattern.compile("\\{\\{\\s*((\\d*)\\s*,\\s*)?(\\p{Alpha}\\w*)?\\s*}}");
+    Pattern PATTERN = Pattern.compile("\\{\\{\\s*((\\d*)\\s*,\\s*)?([A-Za-z0-9_. \\-><'\"\\x7f-\\xff]+)\\s*}}");
 
     /**
      * @param modulePrefix the prefix-stack

--- a/src/test/java/jdbi_modules/base/TestStructuredSqlGenerator.java
+++ b/src/test/java/jdbi_modules/base/TestStructuredSqlGenerator.java
@@ -3,15 +3,19 @@ package jdbi_modules.base;
 import jdbi_modules.internal.PrefixGenerator;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * @since 14.04.2018
  */
-public class TestStructuredSqlGenerator {
+class TestStructuredSqlGenerator {
 
     @Test
     void testAppend() {
@@ -23,6 +27,15 @@ public class TestStructuredSqlGenerator {
                 new Full().sql(new HashSet<>(), new PrefixGenerator(""), Set.of(new Binding("lu", 12)), new Stack<>()), new Stack<>());
         new Full().append(new HashSet<>(), new PrefixGenerator(""), Set.of(),
                 new None().sql(new HashSet<>(), new PrefixGenerator(""), Set.of(), new Stack<>()), new Stack<>());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"id", "mod0exercise.name->>'de'", "exercise.id", "exercise_id", "ÄÖÜßäöü", "_", "-", "0123456789", "a<b", "created - updated",
+            "\"user\""})
+    void testRouting(final String value) {
+        final Stack<String> stack = new Stack<>();
+        stack.push("mod0");
+        assertEquals("\"mod0" + value + "\"", new DynamicSortOrderGenerator(value).sql(new HashSet<>(), new PrefixGenerator(""), Set.of(), stack).sortOrder);
     }
 
     private class None implements StructuredSqlGenerator {
@@ -86,6 +99,20 @@ public class TestStructuredSqlGenerator {
         @Override
         public String getFilter() {
             return "A";
+        }
+    }
+
+    private class DynamicSortOrderGenerator implements StructuredSqlGenerator {
+        private final String sortOrder;
+
+        private DynamicSortOrderGenerator(String sortOrder) {
+            this.sortOrder = sortOrder;
+        }
+
+        @NotNull
+        @Override
+        public String getSortOrder() {
+            return "{{" + this.sortOrder + "}}";
         }
     }
 }


### PR DESCRIPTION
In our project, we would like to do this in the `getSortOrder()` method:

```java
@Override
public String getSortOrder() {
    return "{{exercise.name->>de}} DESC");
}
```

but unfortunately Jdbi-Modules then won't replace the contents inside the parantheses.

I have changed the Pattern in StructuredSqlGenerator to be more permissive and added some actual tests (the previous code in `TestStructuredSqlGenerator` imo does not qualify as test).