### PR TITLE
Cleaner API

### DIFF
--- a/src/main/java/jdbi_modules/Module.java
+++ b/src/main/java/jdbi_modules/Module.java
@@ -58,7 +58,7 @@ public abstract class Module<Type, KeyType, SqlType extends jdbi_modules.SqlType
      * @return the SqlGenerator of this module
      */
     @NotNull
-    public abstract SqlGenerator getSqlGenerator();
+    public abstract SqlGenerator sqlGenerator();
 
     /**
      * A prepare function, allowing the developer to create objects and put them into the store once at the beginning of the mapping.

--- a/src/main/java/jdbi_modules/base/StructuredSqlGenerator.java
+++ b/src/main/java/jdbi_modules/base/StructuredSqlGenerator.java
@@ -34,7 +34,7 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
      * @return the select part of the query.
      */
     @NotNull
-    default String getSelect() {
+    default String select() {
         return "";
     }
 
@@ -42,7 +42,7 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
      * @return the part of the cte clause of the query.
      */
     @NotNull
-    default String getCte() {
+    default String cte() {
         return "";
     }
 
@@ -50,7 +50,7 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
      * @return the part of the from clause of the query.
      */
     @NotNull
-    default String getFrom() {
+    default String from() {
         return "";
     }
 
@@ -58,7 +58,7 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
      * @return the joins of the query.
      */
     @NotNull
-    default String getJoins() {
+    default String joins() {
         return "";
     }
 
@@ -66,15 +66,15 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
      * @return the sort orders of the query.
      */
     @NotNull
-    default String getSortOrder() {
+    default String sortOrder() {
         return "";
     }
 
     /**
-     * @return the filters of the query.
+     * @return the filter of the query.
      */
     @NotNull
-    default String getFilter() {
+    default String filter() {
         return "";
     }
 
@@ -85,12 +85,12 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
                               @NotNull final Set<jdbi_modules.QueryModifier> queryModifiers,
                               @NotNull final Stack<String> modulePrefix) {
         final StructuredSql structuredSql = new StructuredSql(
-                route(modulePrefix, getCte()),
-                route(modulePrefix, getSelect()),
-                route(modulePrefix, getFrom()),
-                route(modulePrefix, getJoins()),
-                route(modulePrefix, getFilter()),
-                route(modulePrefix, getSortOrder()));
+                route(modulePrefix, cte()),
+                route(modulePrefix, select()),
+                route(modulePrefix, from()),
+                route(modulePrefix, joins()),
+                route(modulePrefix, filter()),
+                route(modulePrefix, sortOrder()));
         queryModifiers.stream().map(qm -> structuredSql.applyQueryModifier(qm, queryModifierNameGenerator)).forEach(queryModifierApplier::add);
         return structuredSql;
     }
@@ -102,12 +102,12 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
                                  @NotNull final Set<QueryModifier> queryModifiers,
                                  @NotNull final StructuredSql sqlType,
                                  @NotNull final Stack<String> modulePrefix) {
-        sqlType.cte += (!sqlType.cte.isEmpty() && !getCte().isEmpty() ? ',' : "") + route(modulePrefix, getCte());
-        sqlType.select += (!sqlType.select.isEmpty() && !getSelect().isEmpty() ? ',' : "") + route(modulePrefix, getSelect());
-        sqlType.from += (!sqlType.from.isEmpty() && !getFrom().isEmpty() ? ' ' : "") + route(modulePrefix, getFrom());
-        sqlType.joins += (!sqlType.joins.isEmpty() && !getJoins().isEmpty() ? ' ' : "") + route(modulePrefix, getJoins());
-        sqlType.filter += (!sqlType.filter.isEmpty() && !getFilter().isEmpty() ? " AND " : "") + route(modulePrefix, getFilter());
-        sqlType.sortOrder += (!sqlType.sortOrder.isEmpty() && !getSortOrder().isEmpty() ? ',' : "") + route(modulePrefix, getSortOrder());
+        sqlType.cte += (!sqlType.cte.isEmpty() && !cte().isEmpty() ? ',' : "") + route(modulePrefix, cte());
+        sqlType.select += (!sqlType.select.isEmpty() && !select().isEmpty() ? ',' : "") + route(modulePrefix, select());
+        sqlType.from += (!sqlType.from.isEmpty() && !from().isEmpty() ? ' ' : "") + route(modulePrefix, from());
+        sqlType.joins += (!sqlType.joins.isEmpty() && !joins().isEmpty() ? ' ' : "") + route(modulePrefix, joins());
+        sqlType.filter += (!sqlType.filter.isEmpty() && !filter().isEmpty() ? " AND " : "") + route(modulePrefix, filter());
+        sqlType.sortOrder += (!sqlType.sortOrder.isEmpty() && !sortOrder().isEmpty() ? ',' : "") + route(modulePrefix, sortOrder());
         queryModifiers.stream().map(qm -> sqlType.applyQueryModifier(qm, queryModifierNameGenerator)).forEach(queryModifierApplier::add);
         return sqlType;
     }

--- a/src/main/java/jdbi_modules/internal/ModuleMetaGenerator.java
+++ b/src/main/java/jdbi_modules/internal/ModuleMetaGenerator.java
@@ -62,7 +62,7 @@ public class ModuleMetaGenerator<Type, KeyType, SqlType extends jdbi_modules.Sql
         final Iterator<String> prefixGenerator = new PrefixGenerator("m");
         final Stack<String> prefixStack = new Stack<>();
         prefixStack.push(this.modulePrefix);
-        SqlType sql = prototype.getSqlGenerator().sql(queryModifierApplyer, prefixGenerator, prototype.queryModifiers(), prefixStack);
+        SqlType sql = prototype.sqlGenerator().sql(queryModifierApplyer, prefixGenerator, prototype.queryModifiers(), prefixStack);
         sql = this.appendSqlRecursive(sql, prefixGenerator, queryModifierApplyer, prefixStack);
         return sql;
     }
@@ -71,7 +71,7 @@ public class ModuleMetaGenerator<Type, KeyType, SqlType extends jdbi_modules.Sql
         SqlType sqlAccu = sql;
         for (final ModuleMetaGenerator<Object, Object, SqlType, SqlGenerator<SqlType>> moduleMeta : submodules.values()) {
             prefixStack.push(moduleMeta.modulePrefix);
-            sqlAccu = moduleMeta.prototype.getSqlGenerator().append(queryModifierApplier,
+            sqlAccu = moduleMeta.prototype.sqlGenerator().append(queryModifierApplier,
                     prefixGenerator, moduleMeta.prototype.queryModifiers(), sqlAccu, prefixStack);
             sqlAccu = moduleMeta.appendSqlRecursive(sqlAccu, prefixGenerator, queryModifierApplier, prefixStack);
             prefixStack.pop();

--- a/src/test/java/jdbi_modules/base/TestStructuredSqlGenerator.java
+++ b/src/test/java/jdbi_modules/base/TestStructuredSqlGenerator.java
@@ -28,31 +28,31 @@ public class TestStructuredSqlGenerator {
     private class None implements StructuredSqlGenerator {
         @NotNull
         @Override
-        public String getSelect() {
+        public String select() {
             return "";
         }
 
         @NotNull
         @Override
-        public String getFrom() {
+        public String from() {
             return "";
         }
 
         @NotNull
         @Override
-        public String getJoins() {
+        public String joins() {
             return "";
         }
 
         @NotNull
         @Override
-        public String getSortOrder() {
+        public String sortOrder() {
             return "";
         }
 
         @NotNull
         @Override
-        public String getFilter() {
+        public String filter() {
             return "";
         }
     }
@@ -60,31 +60,31 @@ public class TestStructuredSqlGenerator {
     private class Full implements StructuredSqlGenerator {
         @NotNull
         @Override
-        public String getSelect() {
+        public String select() {
             return "A";
         }
 
         @NotNull
         @Override
-        public String getFrom() {
+        public String from() {
             return "A";
         }
 
         @NotNull
         @Override
-        public String getJoins() {
+        public String joins() {
             return "A";
         }
 
         @NotNull
         @Override
-        public String getSortOrder() {
+        public String sortOrder() {
             return "A";
         }
 
         @NotNull
         @Override
-        public String getFilter() {
+        public String filter() {
             return "A";
         }
     }

--- a/src/test/java/jdbi_modules/realistic/module/FilteredMasterModule.java
+++ b/src/test/java/jdbi_modules/realistic/module/FilteredMasterModule.java
@@ -28,35 +28,35 @@ public class FilteredMasterModule extends MasterModule {
 
     @NotNull
     @Override
-    public StructuredSqlGenerator getSqlGenerator() {
+    public StructuredSqlGenerator sqlGenerator() {
         return new StructuredSqlGenerator() {
             @NotNull
             @Override
-            public String getSelect() {
+            public String select() {
                 return "{{master}}.id AS {{id}}, {{master}}.name AS {{name}}";
             }
 
             @NotNull
             @Override
-            public String getFrom() {
+            public String from() {
                 return "master {{master}}";
             }
 
             @NotNull
             @Override
-            public String getJoins() {
+            public String joins() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getSortOrder() {
+            public String sortOrder() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getFilter() {
+            public String filter() {
                 return "{{master}}.id IN (<ids>)";
             }
         };

--- a/src/test/java/jdbi_modules/realistic/module/MasterModule.java
+++ b/src/test/java/jdbi_modules/realistic/module/MasterModule.java
@@ -59,35 +59,35 @@ public class MasterModule extends Module<Master, Class<?>, StructuredSql, Struct
 
     @NotNull
     @Override
-    public StructuredSqlGenerator getSqlGenerator() {
+    public StructuredSqlGenerator sqlGenerator() {
         return new StructuredSqlGenerator() {
             @NotNull
             @Override
-            public String getSelect() {
+            public String select() {
                 return "{{master}}.id AS {{id}}, {{master}}.name AS {{name}}";
             }
 
             @NotNull
             @Override
-            public String getFrom() {
+            public String from() {
                 return "master {{master}}";
             }
 
             @NotNull
             @Override
-            public String getJoins() {
+            public String joins() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getSortOrder() {
+            public String sortOrder() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getFilter() {
+            public String filter() {
                 return "";
             }
         };

--- a/src/test/java/jdbi_modules/realistic/module/PoolModule.java
+++ b/src/test/java/jdbi_modules/realistic/module/PoolModule.java
@@ -45,35 +45,35 @@ public class PoolModule extends Module<Pool, Class<?>, StructuredSql, Structured
 
     @NotNull
     @Override
-    public StructuredSqlGenerator getSqlGenerator() {
+    public StructuredSqlGenerator sqlGenerator() {
         return new StructuredSqlGenerator() {
             @NotNull
             @Override
-            public String getSelect() {
+            public String select() {
                 return "{{pool}}.id AS {{id}}, {{pool}}.name AS {{name}}";
             }
 
             @NotNull
             @Override
-            public String getFrom() {
+            public String from() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getJoins() {
+            public String joins() {
                 return "LEFT JOIN pool {{pool}} ON {{1, master}}.id = {{pool}}.master_id";
             }
 
             @NotNull
             @Override
-            public String getSortOrder() {
+            public String sortOrder() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getFilter() {
+            public String filter() {
                 return "";
             }
         };

--- a/src/test/java/jdbi_modules/realistic/module/UserModule.java
+++ b/src/test/java/jdbi_modules/realistic/module/UserModule.java
@@ -39,35 +39,35 @@ public class UserModule extends Module<User, Class<?>, StructuredSql, Structured
 
     @NotNull
     @Override
-    public StructuredSqlGenerator getSqlGenerator() {
+    public StructuredSqlGenerator sqlGenerator() {
         return new StructuredSqlGenerator() {
             @NotNull
             @Override
-            public String getSelect() {
+            public String select() {
                 return "{{user}}.id AS {{id}}, {{user}}.name AS {{name}}";
             }
 
             @NotNull
             @Override
-            public String getFrom() {
+            public String from() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getJoins() {
+            public String joins() {
                 return "LEFT JOIN \"user\" {{user}} ON {{1, worker}}.user_id = {{user}}.id";
             }
 
             @NotNull
             @Override
-            public String getSortOrder() {
+            public String sortOrder() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getFilter() {
+            public String filter() {
                 return "";
             }
         };

--- a/src/test/java/jdbi_modules/realistic/module/WorkerModule.java
+++ b/src/test/java/jdbi_modules/realistic/module/WorkerModule.java
@@ -49,35 +49,35 @@ public class WorkerModule extends Module<Worker, Class<?>, StructuredSql, Struct
 
     @NotNull
     @Override
-    public StructuredSqlGenerator getSqlGenerator() {
+    public StructuredSqlGenerator sqlGenerator() {
         return new StructuredSqlGenerator() {
             @NotNull
             @Override
-            public String getSelect() {
+            public String select() {
                 return "{{worker}}.id AS {{id}}, {{worker}}.name AS {{name}}, {{worker}}.position AS {{position}}, {{worker}}.user_id AS {{user_id}}";
             }
 
             @NotNull
             @Override
-            public String getFrom() {
+            public String from() {
                 return "";
             }
 
             @NotNull
             @Override
-            public String getJoins() {
+            public String joins() {
                 return "LEFT JOIN worker {{worker}} ON {{1, pool}}.id = {{worker}}.pool_id";
             }
 
             @NotNull
             @Override
-            public String getSortOrder() {
+            public String sortOrder() {
                 return "{{position}} ASC";
             }
 
             @NotNull
             @Override
-            public String getFilter() {
+            public String filter() {
                 return "";
             }
         };


### PR DESCRIPTION
I took the liberty and refactored some abstract methods (BREAKING CHANGE!).

I removed the "get" prefix from module methods. In my opinion, these methods are not real getters so to speak since they are not tied to actual fields but rather act as data origins themselves.