### PR TITLE
Fix unnecessary space at the end

### DIFF
--- a/src/main/java/jdbi_modules/base/StructuredSql.java
+++ b/src/main/java/jdbi_modules/base/StructuredSql.java
@@ -41,8 +41,10 @@ public class StructuredSql implements SqlType {
 
     @Override
     public final String toQuery() {
-        return (cte.isEmpty() ? "" : "WITH RECURSIVE " + cte + " ") + "SELECT " + select + " FROM " + from + " " + joins
-                + (filter.isEmpty() ? "" : " WHERE " + filter) + (sortOrder.isEmpty() ? "" : " ORDER BY " + sortOrder);
+        return (cte.isEmpty() ? "" : "WITH RECURSIVE " + cte + " ") + "SELECT " + select + " FROM " + from
+                + conditionalConcat(" ", joins)
+                + conditionalConcat(" WHERE ", filter)
+                + conditionalConcat(" ORDER BY ", sortOrder);
     }
 
     /**
@@ -63,5 +65,9 @@ public class StructuredSql implements SqlType {
         filter = filter.replace(inSql, inSql.replace(name, queryModifierName));
         sortOrder = sortOrder.replace(inSql, inSql.replace(name, queryModifierName));
         return query -> queryModifier.apply(query, queryModifierName);
+    }
+
+    private String conditionalConcat(final String prepend, final String str) {
+        return str.isEmpty() ? "" : (prepend + str);
     }
 }


### PR DESCRIPTION
I noticed that sometimes in queries that Jdbi-Modules generates there is an additional space at the end, e.g.,
```sql
SELECT "mod0knowlex_exercise".id AS "mod0id", "mod0knowlex_exercise".randomize_task_pools AS "mod0randomize_task_pools", knowlex_exercise.created, knowlex_exercise.updated, knowlex_exercise.disabled, knowlex_exercise.name, knowlex_exercise.description FROM (SELECT exercise.*, knowlex_exercise.randomize_task_pools FROM knowlex_exercise JOIN exercise ON exercise.id = knowlex_exercise.id WHERE (exercise.id = :m0) AND (disabled = :m1)) "mod0knowlex_exercise" ", rewritten:"SELECT "mod0knowlex_exercise".id AS "mod0id", "mod0knowlex_exercise".randomize_task_pools AS "mod0randomize_task_pools", knowlex_exercise.created, knowlex_exercise.updated, knowlex_exercise.disabled, knowlex_exercise.name, knowlex_exercise.description FROM (SELECT exercise.*, knowlex_exercise.randomize_task_pools FROM knowlex_exercise JOIN exercise ON exercise.id = knowlex_exercise.id WHERE (exercise.id = :m0) AND (disabled = :m1)) "mod0knowlex_exercise" ", parsed:"ParsedSql{sql='SELECT "mod0knowlex_exercise".id AS "mod0id", "mod0knowlex_exercise".randomize_task_pools AS "mod0randomize_task_pools", knowlex_exercise.created, knowlex_exercise.updated, knowlex_exercise.disabled, knowlex_exercise.name, knowlex_exercise.description FROM (SELECT exercise.*, knowlex_exercise.randomize_task_pools FROM knowlex_exercise JOIN exercise ON exercise.id = knowlex_exercise.id WHERE (exercise.id = ?) AND (disabled = ?)) "mod0knowlex_exercise" ```

This PR fixes that.