### PR TITLE
Fix missing spaces after comma

### DIFF
--- a/src/main/java/jdbi_modules/base/StructuredSqlGenerator.java
+++ b/src/main/java/jdbi_modules/base/StructuredSqlGenerator.java
@@ -102,12 +102,12 @@ public interface StructuredSqlGenerator extends jdbi_modules.SqlGenerator<Struct
                                  @NotNull final Set<QueryModifier> queryModifiers,
                                  @NotNull final StructuredSql sqlType,
                                  @NotNull final Stack<String> modulePrefix) {
-        sqlType.cte += (!sqlType.cte.isEmpty() && !cte().isEmpty() ? ',' : "") + route(modulePrefix, cte());
+        sqlType.cte += (!sqlType.cte.isEmpty() && !cte().isEmpty() ? ", " : "") + route(modulePrefix, cte());
         sqlType.select += (!sqlType.select.isEmpty() && !select().isEmpty() ? ',' : "") + route(modulePrefix, select());
         sqlType.from += (!sqlType.from.isEmpty() && !from().isEmpty() ? ' ' : "") + route(modulePrefix, from());
         sqlType.joins += (!sqlType.joins.isEmpty() && !joins().isEmpty() ? ' ' : "") + route(modulePrefix, joins());
         sqlType.filter += (!sqlType.filter.isEmpty() && !filter().isEmpty() ? " AND " : "") + route(modulePrefix, filter());
-        sqlType.sortOrder += (!sqlType.sortOrder.isEmpty() && !sortOrder().isEmpty() ? ',' : "") + route(modulePrefix, sortOrder());
+        sqlType.sortOrder += (!sqlType.sortOrder.isEmpty() && !sortOrder().isEmpty() ? ", " : "") + route(modulePrefix, sortOrder());
         queryModifiers.stream().map(qm -> sqlType.applyQueryModifier(qm, queryModifierNameGenerator)).forEach(queryModifierApplier::add);
         return sqlType;
     }


### PR DESCRIPTION
I have identified yet another case (actually two cases) where a comma is missing:

```sql
SELECT "mod0exercise".id AS "mod0id", "mod0exercise".created AS "mod0created", "mod0exercise".updated AS "mod0updated", "mod0exercise".type AS "mod0type", "mod0exercise".disabled AS "mod0disabled", "mod0exercise".name AS "mod0name", "mod0exercise".description AS "mod0description","mod1genex_exercise".id AS "mod1id", "mod1genex_exercise".generator_class AS "mod1generator_class", "mod1genex_exercise".frontend_identifier AS "mod1frontend_identifier","mod2knowlex_exercise".id AS "mod2id", "mod2knowlex_exercise".randomize_task_pools AS "mod2randomize_task_pools","mod3codex_exercise".id AS "mod3id", "mod3codex_exercise".difficulty_points AS "mod3difficulty_points", "mod3codex_exercise".scope AS "mod3scope", "mod3codex_exercise".frontend_identifier AS "mod3frontend_identifier","mod4java_codex_exercise".id AS "mod4id", "mod4java_codex_exercise".min_loop_count AS "mod4min_loop_count", "mod4java_codex_exercise".max_loop_count AS "mod4max_loop_count", "mod4java_codex_exercise".min_for_loop_count AS "mod4min_for_loop_count", "mod4java_codex_exercise".max_for_loop_count AS "mod4max_for_loop_count", "mod4java_codex_exercise".min_while_loop_count AS "mod4min_while_loop_count", "mod4java_codex_exercise".max_while_loop_count AS "mod4max_while_loop_count", "mod4java_codex_exercise".min_for_each_loop_count AS "mod4min_for_each_loop_count", "mod4java_codex_exercise".max_for_each_loop_count AS "mod4max_for_each_loop_count", "mod4java_codex_exercise".min_do_while_loop_count AS "mod4min_do_while_loop_count", "mod4java_codex_exercise".max_do_while_loop_count AS "mod4max_do_while_loop_count", "mod4java_codex_exercise".log_allowed AS "mod4log_allowed","mod5mips_codex_exercise".id AS "mod5id", "mod5mips_codex_exercise".text AS "mod5text", "mod5mips_codex_exercise".whitelist AS "mod5whitelist", "mod5mips_codex_exercise".pseudo_whitelist AS "mod5pseudo_whitelist", "mod5mips_codex_exercise".max_instructions AS "mod5max_instructions" FROM (SELECT * FROM exercise WHERE (exercise.disabled = :m5) ORDER BY updated DESC LIMIT :m0 OFFSET :m1) "mod0exercise" LEFT JOIN genex_exercise "mod1genex_exercise" ON "mod1genex_exercise".id = "mod0exercise".id LEFT JOIN knowlex_exercise "mod2knowlex_exercise" ON "mod2knowlex_exercise".id = "mod0exercise".id LEFT JOIN codex_exercise "mod3codex_exercise" ON "mod3codex_exercise".id = "mod0exercise".id LEFT JOIN java_codex_exercise "mod4java_codex_exercise" ON "mod4java_codex_exercise".id = "mod3codex_exercise".id LEFT JOIN mips_codex_exercise "mod5mips_codex_exercise" ON "mod5mips_codex_exercise".id = "mod3codex_exercise".id ORDER BY "mod0exercise".updated DESC
```

First, when multiple modules' SQL contains at least one SELECT column, a space after the comma is missing.
Second, the ORDER BY clause should also contain a space after the comma.